### PR TITLE
add 多米音樂 mobile apps, iQiyi, QQVideo PC Client support

### DIFF
--- a/shared/urls.js
+++ b/shared/urls.js
@@ -140,6 +140,9 @@ unblock_youku.server_extra_urls = [
     'http://api.letv.com/getipgeo',
     'http://m.letv.com/api/geturl?*',
     'http://serviceinfo.sdk.duomi.com/api/serviceinfo/getserverlist*',
+    // for PC Clients only
+    'http://iplocation.geo.qiyi.com/cityjson'
+    'http://sns.video.qq.com/tunnel/fcgi-bin/tunnel*'
     // for 3rd party's DNS for Apple TV (see pull request #78)
     'http://180.153.225.136/*',
     'http://118.244.244.124/*',


### PR DESCRIPTION
多米音樂這個應用設計比較tricky, 測試時
它無視系統proxy, 直接連接URL, 從中取得參數後, 刻意使用自己的代理連接音樂資源
上面URL是我用iptables強制route過來才看到的
