### PR TITLE
[LETV] remove g3.letv.cn as it seem to be not needed anymore & seriously affecting the speed.

### DIFF
--- a/shared/urls.js
+++ b/shared/urls.js
@@ -31,7 +31,7 @@ unblock_youku.common_urls = [
     'http://hot.vrs.sohu.com/*',
     'http://live.tv.sohu.com/live/player*',
     'http://hot.vrs.letv.com/*',
-    'http://g3.letv.cn/*',
+    //'http://g3.letv.cn/*',
     'http://data.video.qiyi.com/*',
 
     // cause oversea servers unusable?


### PR DESCRIPTION
Previously reported @ #77 
Look like LETV don't block it now.
Tested on an android phone & PC chrome.
Also it is seriously affecting the speed as it effectively disabled the CDN of LETV.
