### PR TITLE
Add Douban.fm support (extension only)

### DIFF
--- a/shared/urls.js
+++ b/shared/urls.js
@@ -112,7 +112,9 @@ unblock_youku.chrome_extra_urls = [
     'http://imanhua.com/comic/*',
     'http://www.imanhua.com/comic/*',
     'http://imanhua.com/v2*',
-    'http://www.imanhua.com/v2*'
+    'http://www.imanhua.com/v2*',
+    'http://www.douban.fm/*',
+    'http://douban.fm/*'
 ];
 
 // only for server


### PR DESCRIPTION
豆瓣电台最近针对香港（貌似只是香港）关闭服务，测试过发现X Forwarded For这个header即可绕过。

Ref Issue #122
