### PR TITLE
#137 workaround

### DIFF
--- a/shared/urls.js
+++ b/shared/urls.js
@@ -52,6 +52,7 @@ unblock_youku.common_urls = [
     'http://tjsa.video.qq.com/getinfo*',
     'http://a10.video.qq.com/getinfo*',
     'http://xyy.video.qq.com/getinfo*',
+    'http://vcp.video.qq.com/getinfo*',
     'http://vsh.video.qq.com/getinfo*',
     'http://vbj.video.qq.com/getinfo*',
     'http://bobo.video.qq.com/getinfo*',


### PR DESCRIPTION
when requests to vv.video.qq.com became timeout, it will switch to these following domains for address resolution.
