### PR TITLE
fixed film.qq.com

### DIFF
--- a/shared/urls.js
+++ b/shared/urls.js
@@ -57,6 +57,7 @@ unblock_youku.common_urls = [
     'http://vbj.video.qq.com/getinfo*',
     'http://bobo.video.qq.com/getinfo*',
     'http://flvs.video.qq.com/getinfo*',
+    'http://rcgi.video.qq.com/report*',
 
     'http://geo.js.kankan.xunlei.com/*',
     'http://web-play.pptv.com/*',


### PR DESCRIPTION
影片已经可以开始播放了，比如
http://film.qq.com/cover/5/5gic79432my5ja0.html

另外我第一次进入首页 http://film.qq.com 时被 redirect 到了 http://film.qq.com/oversea.html ，刷新一次再进入又不跳转了。。无法复现
