### PR TITLE
迅雷快传 自动跳转至 迅雷看看 （美国）

### DIFF
--- a/shared/urls.js
+++ b/shared/urls.js
@@ -63,6 +63,9 @@ unblock_youku.common_urls = [
     'http://rcgi.video.qq.com/report*',
 
     'http://geo.js.kankan.xunlei.com/*',
+    'http://ip.kankan.xunlei.com/*',
+    'http://kuai.xunlei.com/*',
+
     'http://web-play.pptv.com/*',
     'http://web-play.pplive.cn/*',
     // 'http://c1.pptv.com/*',
@@ -72,7 +75,6 @@ unblock_youku.common_urls = [
     'http://ipservice.163.com/*',
     'http://so.open.163.com/open/info.htm*',
     'http://zb.s.qq.com/*',
-    'http://ip.kankan.xunlei.com/*',
     'http://vxml.56.com/json/*',
 
     'http://music.sina.com.cn/yueku/intro/*',


### PR DESCRIPTION
kuai.xunlei.com is only responsible for files and directories URL retrieval for KuaiChuan service but not the actual largely sized files themselves.
