### PR TITLE
Add whitelist

### DIFF
--- a/chrome/proxy.js
+++ b/chrome/proxy.js
@@ -23,7 +23,7 @@
 
 
 function setup_pac_data(proxy_domain) {
-    var pac_data = urls2pac(unblock_youku.normal_url_list, proxy_domain + ':80');
+    var pac_data = urls2pac([], unblock_youku.normal_url_list, proxy_domain + ':80');
     var proxy_config = {
         mode: 'pac_script',
         pacScript: {

--- a/server/utils.js
+++ b/server/utils.js
@@ -87,6 +87,11 @@ function get_real_target(req_path) {
 
 function is_valid_url(target_url) {
     var i;
+    for (i = 0; i < shared_urls.url_regex_whitelist.length; i++) {
+	if (shared_urls.url_regex_whitelist[i].test(target_url)) {
+	    return false;
+	}
+    }
     for (i = 0; i < shared_urls.url_regex_list.length; i++) {
         if (shared_urls.url_regex_list[i].test(target_url)) {
             return true;
@@ -306,7 +311,7 @@ function generate_pac_file(proxy_addr_port) {
         ' * take no responsibilities for any consequences.\n' +
         ' */\n' +
         uglify.minify(
-            shared_tools.urls2pac(shared_urls.url_list, proxy_addr_port),
+            shared_tools.urls2pac(shared_urls.url_whitelist, shared_urls.url_list, proxy_addr_port),
             {fromString: true,}
         ).code;
 }

--- a/shared/tools.js
+++ b/shared/tools.js
@@ -26,12 +26,29 @@ function new_random_ip() {
 }
 
 
-function urls2pac(url_list, proxy_server) {
+function urls2pac(url_whitelist, url_list, proxy_server) {
     "use strict";
     var s = 'function FindProxyForURL(url, host) {\n' +
             '    if (';
 
     var i;
+
+    if (url_whitelist.length > 0) {
+	for (i = 0; i < url_whitelist.length; i++) {
+            s += 'shExpMatch(url, "' + url_whitelist[i] + '")';
+            if (i === url_whitelist.length - 1) {
+		s += ') {\n';
+            } else {
+		s += ' ||\n            ';
+            }
+	}
+
+	s += '        return "DIRECT";\n' +
+            '    }\n';
+
+	s += 'else if (';
+    }
+    
     for (i = 0; i < url_list.length; i++) {
         s += 'shExpMatch(url, "' + url_list[i] + '")';
         if (i === url_list.length - 1) {

--- a/shared/urls.js
+++ b/shared/urls.js
@@ -146,6 +146,12 @@ unblock_youku.chrome_extra_urls = [
 ];
 
 // only for server
+
+unblock_youku.server_whitelist_urls = [
+    // those does not need to go throw proxy
+    'http://*/ipad?file=/*'
+];
+
 unblock_youku.server_extra_urls = [
     // for Mobile apps    // Video apps
     'http://api.3g.youku.com/layout*',
@@ -232,3 +238,5 @@ function urls2regexs(url_list) {
 var exports = exports || {};
 exports.url_list = unblock_youku.common_urls.concat(unblock_youku.server_extra_urls);
 exports.url_regex_list = urls2regexs(exports.url_list);
+exports.url_whitelist = unblock_youku.server_whitelist_urls;
+exports.url_regex_whitelist = urls2regexs(exports.url_whitelist);


### PR DESCRIPTION
A whitelist will override the normal proxy matching both in proxy.pac and in server processing. It will add flexibility to the tool to deal with complicated situations.

This is needed for the Sohu video app on iPad to work:
e.g.: 'http://220.181.19.218/*' is listed in unblock_youku.common_urls. However, a video file also takes a url like: 'http://220.181.19.218/ipad?file=*'. A white list will allow this video file to be downloaded directly.

Thanks.
