### PR TITLE
Squash dns-reverse-proxy branch for pull // FREEBIE

### DIFF
--- a/dns-reverse-proxy/Makefile
+++ b/dns-reverse-proxy/Makefile
@@ -1,0 +1,35 @@
+TOP := $(dir $(lastword $(MAKEFILE_LIST)))
+# node binary is renamed to nodejs on Debian
+NODE = $(shell which nodejs || which node)
+
+# locate rapydscript file
+# pass NPM_PATH to make will override rapydscript bin path
+RAPYDSCRIPT = rapydscript
+NPM = $(shell which npm)
+ifndef NPM_PATH
+	NPM_PATH = $(shell ${NPM} bin)
+endif
+
+ifeq (,$(wildcard ${NPM_PATH}))
+	NPM_PATH =
+	RAPYDSCRIPT := $(shell which ${RAPYDSCRIPT})
+else
+	RAPYDSCRIPT := ${NPM_PATH}/${RAPYDSCRIPT}
+endif
+
+JS_TARGET = dns-proxy.js \
+	    droxy.js \
+	    reverse-sogou-proxy.js \
+	    lutils.js \
+
+all: $(JS_TARGET)
+
+%.js: %.py
+ifeq (, $(wildcard ${RAPYDSCRIPT}))
+	$(error please install 'rapydscript' by `npm install rapydscript`)
+endif
+	${NODE} ${RAPYDSCRIPT} $< --screw-ie8 -p > $@
+
+.PHONY: all
+
+# vim:fileencoding=utf-8:sw=8:tabstop=8

--- a/dns-reverse-proxy/README.md
+++ b/dns-reverse-proxy/README.md
@@ -1,0 +1,221 @@
+# About #
+
+The file in this directory is a reverse HTTP proxy server combined with a DNS
+proxy server (droxy).
+
+When pointing your DNS resolver to `droxy`, droxy will redirect _some_ domain
+names to itself. The droxy will then be able to transparently proxy the HTTP
+requests to the __redirected domain__ through the builtin HTTP proxy server.
+The builtin HTTP proxy will go through sogou proxy server by default.
+
+# Disclaimer #
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# Privileged Port #
+
+When running the server, if you see errors like this:
+```
+{ [Error: bind EACCES] code: 'EACCES', errno: 'EACCES', syscall: 'bind' }
+
+events.js:72
+        throw er; // Unhandled 'error' event
+              ^
+Error: listen EACCES
+    at errnoException (net.js:904:11)
+    at Server._listen2 (net.js:1023:19)
+    at listen (net.js:1064:10)
+    at net.js:1146:9
+    at dns.js:72:18
+    at process._tickCallback (node.js:415:13)
+    at Function.Module.runMain (module.js:499:11)
+    at startup (node.js:119:16)
+    at node.js:902:3
+```
+
+This is an error of `privileged ports`. Search internet for more detailed
+information.
+
+To solve it, there are a few ways:
+
+  * port-forward with iptables or alike
+  * run the server under root or sudo
+  * use `setcap` to give all node.js script the port privilege
+  * suid the server script file and run with root privilege
+  * some systemd capability setting if you are into systemd
+
+As you can see, running it under root is easier. But root is dangerous!
+Therefore don't run any server under root!!
+
+Anyway, use your own judgement. We're not responsible for any damage caused
+by running the server. See the Disclaimer above.
+
+# Dependency #
+
+## Build Dependency ##
+
+ * rapydscript
+
+## Runtime Dependency ##
+
+ * http-proxy
+ * optimist
+
+### Optional Runtime Dependency ###
+
+ * chroot -- for chroot and drop root priviledge if run under `root`
+
+# Usage #
+
+Install dependencies by
+```
+    cd dns-reverse-proxy/
+    npm install rapydscript http-proxy optimist
+```
+
+Compile rapydscripts to javascripts
+```
+    make
+```
+
+Run the server
+```sh
+    sudo nodejs droxy.js --help
+```
+
+Options can be save/load from a config file
+```sh
+    sudo nodejs droxy.js --config sample-config.json
+```
+
+Now you can set the DNS of your computer to the local IP running the dns
+reverse proxy, and let sogou work its magic.
+
+```
+$ nodejs droxy.js -h
+DNS Reverse Proxy(droxy) server with unblock-youku
+Usage:
+	nodejs ./droxy.js [--options]
+
+Options:
+  --ip               local IP address to listen on        [default: "0.0.0.0"]
+  --dns-host         remote dns host. default: first in /etc/resolv.conf      
+  --sogou-dns        DNS used to lookup IP of sogou proxy servers
+                                                               [default: null]
+  --sogou-network    choose between "edu" and "dxt"            [default: null]
+  --extra-url-list   load extra url redirect list from a JSON file            
+  --ext-ip           for public DNS, the DNS proxy route to the given public
+                     IP. If set to "lookup", try to find the public IP
+                     through http://httpbin.org/ip. If a domain name is
+                     given, the IP will be lookup through DNS  [default: null]
+  --dns-no-relay     don't relay un-routed domain query to upstream DNS       
+  --dns-rate-limit   DNS query rate limit per sec per IP. -1 = no limit
+                                                                 [default: 25]
+  --dns-port         local port for the DNS proxy to listen on. Useful with
+                     port forward                                [default: 53]
+  --http-port        local port for the HTTP proxy to listen on. Useful with
+                     port forward                                [default: 80]
+  --http-rate-limit  HTTP proxy rate limit per sec per IP. -1 = no limit
+                                                                 [default: 20]
+  --run-as           run as unpriviledged user (sudo/root)
+                                                           [default: "nobody"]
+  --chroot-dir       chroot to given directory (sudo/root). Should copy
+                     /etc/resolv.conf to /newroot/etc/resolv.conf and make it
+                     readable if needed         [default: "/var/chroot/droxy"]
+  --config, -c       load the given configuration file
+                    [default: "/home/johndoe/.config/ub.uku.droxy/config.json"]
+  --debug, -D        debug mode                                               
+  --help, -h         print help message                                       
+
+```
+
+## dns-no-relay ##
+
+This option is not needed if you run the server on local LAN network. It is
+used to protect the server from DoS attack when running on public network.
+
+With the option `--dns-no-relay`, only DNS queries for routed domain names are
+handled by the builtin DNS server. For other general domain name lookup, a
+`Refused` error message will be returned. Next, another DNS server will be used
+to query for the general domain names.
+
+When `--dns-no-relay` is used, in order to get proper DNS lookup for all the
+domain names, the client OS should have at least one backup DNS server in
+addition to the DNS proxy server.
+
+Actually, a backup DNS server is always a good idea, even with the DNS relay.
+In case the droxy server is down for whatever reason, a backup DNS will at
+least keep other internet activities intact.
+
+For example, in `/etc/resovle.conf`:
+
+```
+nameserver 192.168.1.5
+nameserver 8.8.4.4
+nameserver 8.8.8.8
+```
+
+Where the `192.168.1.5` is our DNS proxy server. The other 2 servers are backup
+servers for non-routed domain names. Of course, using DNS provided by ISP in
+general is preferred over ~evil~ public DNS like 8.8.8.8.
+
+## extra-url-list ##
+
+Extra url patterns can be supplied with the `--extra-url-list` option. The
+option accept a argument as a JSON filename. The JSON file should contain a
+single array of url pattern strings, like:
+
+```json
+["http://example1.net/vid/*.cgi", "http://example2.net/vod/bin/*"]
+```
+
+## ext-ip ##
+
+**NOTE**: Don't run a public DNS proxy server if you don't have to! People are
+hacking servers around the clock!
+
+If a public DNS proxy server is setup behind a router, the `--ext-ip` option
+could be used to set the public IP address of the router.
+
+Then the port `53`(DNS) and port `80`(HTTPd) of the router need to be forwarded
+to the machine running the droxy server.
+
+There are some facilities to help with setup the droxy server with dynamic IP.
+
+If the parameter `lookup` is given to the `--ext-ip` option, the external IP
+will be looked up through `http://httpbin.org/ip` periodically.
+
+If a domain name instead of a IP is given to the the `--ext-ip` option, a DNS
+lookup for the domain name will be done to find the corresponding IP
+periodically.
+
+`--dns-port` and `--http-port` might be useful when port forward is done.
+
+## Drop root privilege ##
+
+If the package `chroot` is installed, the server will drop root privilege and
+chroot when **running under root**.
+
+The options `--run-as` and `--chroot-dir` will take part in the action.
+
+# Hackinig #
+
+The code were mostly written in [RapydScript](http://rapydscript.pyjeon.com/)
+which is a pre-compiler for JavaScript, just like CoffeeScript. The syntax is
+basic Python with a few javascript concept.
+
+CoffeeScript syntax is just too much non-python to the taste of mine
+(mozbugbox). RapydScript is much more python look alike.
+
+Let's just see how long before the author of Rapydscript lost his enthusiasm
+over maintaining the pre-compiler. Finger crossed.
+

--- a/dns-reverse-proxy/dns-proxy.py
+++ b/dns-reverse-proxy/dns-proxy.py
@@ -1,0 +1,928 @@
+# vim:fileencoding=utf-8:sw=4:et:syntax=python
+# DNS proxy server that hijack some filtered domain
+
+# RFC5625: DNS Proxy Implementation Guidelines
+# https://tools.ietf.org/html/rfc5625
+dgram = require("dgram")
+dns = require("dns")
+EventEmitter = require("events").EventEmitter
+lutils = require("./lutils")
+log = lutils.logger
+
+BUFFER_SIZE = 2048 # STANDARD size should be 512 but who knows
+DEFAULT_TTL = 600 # time to live for our fake A record, in seconds
+DNS_RATE_LIMIT = 20 # rate limit: lookup/second
+
+# 8.8.8.8 google
+# 8.8.4.4 google
+# 156.154.70.1 Dnsadvantage
+# 156.154.71.1 Dnsadvantage
+# 208.67.222.222 OpenDNS
+# 208.67.220.220 OpenDNS
+# 198.153.192.1 Norton
+# 198.153.194.1 Norton
+DNS_DEFAULT_HOST = "8.8.8.8"
+
+DNS_PORT = 53
+DNS_ENCODING = "ascii"
+DNS_POINTER_FLAG = 0xC0
+DNS_FLAGS = {
+    QR: 0x01 << 15,
+    OPCODE: 0x0F << 11,
+    AA: 0x01 << 10,
+    TC: 0x01 << 9,
+    RD: 0x01 << 8,
+    RA: 0x01 << 7,
+    RCODE: 0x0F << 0,
+}
+
+# https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml
+DNS_RCODES = {
+        "NoError": 0,
+        "FormErr": 1,
+        "ServFail": 2,
+        "NXDomain": 3,
+        "NotImp": 4,
+        "Refused": 5,
+        "YXDomain": 6,
+        "YXRRSet": 7,
+        "NXRRSet": 8,
+        "NotAuth": 9,
+        "NotAuth": 9,
+        "NotZone": 10,
+        #"Unassigned": 11-15,
+        "BADVERS": 16,
+        "BADSIG": 16,
+        "BADKEY": 17,
+        "BADTIME": 18,
+        "BADMODE": 19,
+        "BADNAME": 20,
+        "BADALG": 21,
+        "BADTRUNC": 22,
+        #"Unassigned": 23-3840,
+        #"Reserved": 3841-4095,
+        #"Unassigned": 4096-65534,
+        #"Reserved": 65535,
+}
+DNS_CLASSES = {
+        IN: 1,
+        CS: 2,
+        CH: 3,
+        HS: 4,
+        }
+
+# Resource Record (RR) Type
+RECORD_TYPES = {
+        A: 1,
+        NS: 2,
+        MD: 3,
+        MF: 4,
+        CNAME: 5,
+        SOA: 6,
+        MB: 7,
+        MG: 8,
+        MR: 9,
+        NULL: 10,
+        WKS: 11,
+        PTR: 12,
+        HINFO: 13,
+        MINFO: 14,
+        MX: 15,
+        TXT: 16,
+        RP: 17,
+        AFSDB: 18,
+        X25: 19,
+        ISDN: 20,
+        RT: 21,
+        NSAP: 22,
+        NSAPPTR: 23,
+        SIG: 24,
+        KEY: 25,
+        PX: 26,
+        GPOS: 27,
+        AAAA: 28,
+        LOC: 29,
+        NXT: 30,
+        EID: 31,
+        NIMLOC: 32,
+        SRV: 33,
+        ATMA: 34,
+        NAPTR: 35,
+        KX: 36,
+        CERT: 37,
+        A6: 38,
+        DNAME: 39,
+        SINK: 40,
+        OPT: 41,
+        APL: 42,
+        DS: 43,
+        SSHFP: 44,
+        IPSECKEY: 45,
+        RRSIG: 46,
+        NSEC: 47,
+        DNSKEY: 48,
+        DHCID: 49,
+        NSEC3: 50,
+        NSEC3PARAM: 51,
+        TLSA: 52,
+        HIP: 55,
+        NINFO: 56,
+        RKEY: 57,
+        TALINK: 58,
+        CDS: 59,
+        SPF: 99,
+        UINFO: 100,
+        UID: 101,
+        GID: 102,
+        UNSPEC: 103,
+        NID: 104,
+        L32: 105,
+        L64: 106,
+        LP: 107,
+        EUI48: 108,
+        EUI64: 109,
+        TKEY: 249,
+        TSIG: 250,
+        IXFR: 251,
+        AXFR: 252,
+        MAILB: 253,
+        MAILA: 254,
+        ANY: 255,
+        URI: 256,
+        CAA: 257,
+        TA: 32768,
+        DLV: 32769,
+        }
+
+def read_domain(buf, offset):
+    """ parse encoded domain names
+    03www05baidu03com00 => www.baidu.com
+    """
+    domain = []
+    raw_offset = -1
+    #console.warn("read_domain", buf, offset)
+    while True:
+        llen = buf.readUInt8(offset); offset += 1
+        if llen == 0: break
+        is_pointer_type = llen & DNS_POINTER_FLAG
+        if is_pointer_type is not 0:
+            # pointer type point to another label with global 16bit offset
+            lower_llen = buf.readUInt8(offset); offset += 1
+            if raw_offset < 0:
+                # save domain name offset at 1st pointer type
+                raw_offset = offset
+            offset = ((llen & (~DNS_POINTER_FLAG)) << 8 | lower_llen)
+            continue # reread label from the new offset
+
+        label = buf.toString(DNS_ENCODING, offset, offset + llen)
+        domain.push(label)
+        offset += llen
+
+    if raw_offset >= 0:
+        offset = raw_offset
+    ret = {
+            "name": domain.join("."),
+            "offset": offset,
+            "has_pointer_type": raw_offset >= 0
+            }
+    #console.warn(ret)
+    return ret
+
+def write_domain(buf, name, offset, do_compress=True):
+    """Write a domain name in DNS encoding"""
+    #console.log("name", name)
+    if not buf.offset_cache:
+        buf.offset_cache = {}
+    #console.warn("Packable?", do_compress, name, buf.offset_cache)
+    if name in buf.offset_cache and do_compress is True:
+        pointer = buf.offset_cache[name]
+        buf.writeUInt16BE((DNS_POINTER_FLAG<<8)|pointer, offset); offset += 2
+        #console.warn("compressed:", name)
+    else:
+        # record offset of each piece for label compression
+        parts = name.split(".")
+        buf.offset_cache[name] = offset
+        wlen = buf.write(parts[0], offset + 1, DNS_ENCODING)
+        buf.writeUInt8(wlen, offset); offset += 1
+        offset += wlen
+        if parts.length > 1:
+            tail = parts.slice(1)
+            offset = write_domain(buf, tail.join("."), offset, do_compress)
+        else:
+            buf.writeUInt8(0, offset); offset += 1
+    return offset
+
+def decode_base64_label(label_string):
+    lbuf = Buffer(label_string, "base64")
+    name_info = read_domain(lbuf, 0)
+    return name_info["name"]
+
+#console.log(read_domain(Buffer("\03www\04sohu\03com\00", "binary"), 0))
+#console.log(read_domain(Buffer("\04sohu\03com\xC0\x0B\02cn\00", "binary"), 0))
+
+def encode_ip(aip):
+    """Encode a string ip to uint32 coded as base64"""
+    buf = Buffer(4)
+    parts = aip.split(".")
+    for i, d in enumerate(parts):
+        buf[i] = parseInt(d)
+    #console.log(buf.readUInt32BE(0))
+    return buf.toString("base64", 0, 4)
+
+def decode_ip(eip):
+    """decode a base64 encoded uint32 ip to string ip"""
+    result = []
+    buf = Buffer(eip, "base64")
+    ip32 = buf.readUInt32BE(0)
+
+    while ip32 > 0:
+        b = ip32 % 0x100
+        ip32 = int(ip32 / 0x100)
+        result.push("" + b)
+    while len(result) < 4:
+        result.push("0")
+    result.reverse()
+    result = result.join(".")
+    #console.log(result)
+    return result
+
+#console.log(decode_ip("fwAAAQ=="))
+#console.log(encode_ip("127.0.0.1"), "fwAAAQ==")
+
+class DnsError(Error):
+    def __init__(self, msg):
+        Error.__init__(self, msg)
+        self.name = "DnsError"
+        self.message = msg
+
+# DNS message format:
+# http://www.zytrax.com/books/dns/ch15/
+class DnsMessage:
+    def __init__(self, buf=None):
+        self.id = 0
+        self.flags = 0
+        self.question = []
+        self.answer = []
+        self.authority = []
+        self.additional = []
+        self.has_pointer_type = False
+
+        if buf is not None:
+            self.parse_buffer(buf)
+
+    def parse_buffer(self, buf):
+        """Parse content in buf as a DNS message"""
+        offset = 0
+        offset = self.parse_header(buf, offset)
+        offset = self.parse_records(buf, offset)
+
+    def parse_header(self, buf, offset):
+        """Parse DNS headers"""
+        self.id = buf.readUInt16BE(offset); offset += 2
+        self.flags = buf.readUInt16BE(offset); offset += 2
+        return offset
+
+    def parse_records(self, buf, offset):
+        """Parse question/answser record of a DNS message"""
+        question_count = buf.readUInt16BE(offset); offset += 2
+        answer_count = buf.readUInt16BE(offset); offset += 2
+        authority_count = buf.readUInt16BE(offset); offset += 2
+        additional_count = buf.readUInt16BE(offset); offset += 2
+        self.question, offset = self.parse_question(buf, offset,
+                question_count)
+        self.answer, offset = self.parse_resource_record(buf, offset,
+                answer_count)
+        self.authority, offset = self.parse_resource_record(buf, offset,
+                authority_count)
+        self.additional, offset = self.parse_resource_record(buf, offset,
+                additional_count)
+        return offset
+
+    def parse_one_question(self, buf, offset):
+        """Parse one piece of the question record"""
+        domain_info = read_domain(buf, offset)
+        if domain_info["has_pointer_type"] == True:
+            self.has_pointer_type = True
+        offset = domain_info["offset"]
+        qtype = buf.readUInt16BE(offset); offset += 2
+        klass = buf.readUInt16BE(offset); offset += 2
+        data = {
+            "name": domain_info["name"],
+            "type": qtype,
+            "class": klass
+            }
+        return data, offset
+
+    def parse_question(self, buf, offset, count):
+        """
+            QNAME: domain name
+            QTYPE: query type: A, MX, ...
+            QCLASS: request record being requested
+        """
+        questions = []
+        for i in [0 til count]:
+            data, offset = self.parse_one_question(buf, offset)
+            questions.push(data)
+        return questions, offset
+
+    def parse_resource_record(self, buf, offset, count):
+        """
+            The RR data
+            QNAME: domain name
+            QTYPE: query type: A, MX, ...
+            QCLASS: request record being requested
+            TTL:   time to live in seconds (uint32)
+            RLENGTH: record length (uint16)
+            RDATA: record data (For A query, a uint32 for IP)
+        """
+        resource_record = []
+        for i in [0 til count]:
+            data, offset = self.parse_one_question(buf, offset)
+            data["ttl"] = buf.readUInt32BE(offset); offset += 4
+            rdlen = buf.readUInt16BE(offset); offset += 2
+            data["rdata"] = self.read_rdata(buf, offset, rdlen, data["type"])
+            offset += rdlen
+            resource_record.push(data)
+        #console.warn("resource_record", resource_record)
+        return resource_record, offset
+
+    def read_rdata(self, buf, offset, rdlen, data_type):
+        """Read rdata from the buffer
+           To decompress labels, we have to take account of the record type
+        """
+        tmp_buf = Buffer(BUFFER_SIZE)
+        tmp_offset = 0
+        # <<DNS and BIND>> Appendix A
+        # Appendix A. DNS Message Format and Resource Records
+        if data_type in [RECORD_TYPES.CNAME, RECORD_TYPES.DNAME,
+                RECORD_TYPES.PTR, RECORD_TYPES.NS,
+                RECORD_TYPES.MADNAME, RECORD_TYPES.MGMNAME,
+                RECORD_TYPES.MR]:
+            label_info = read_domain(buf, offset)
+            clen = write_domain(tmp_buf, label_info["name"], 0, False)
+            result = tmp_buf.toString("base64", 0, clen)
+        elif data_type in [RECORD_TYPES.MX]:
+            delta = 0
+            pref = buf.readUInt16BE(offset); delta += 2
+            clen = tmp_buf.writeUInt16BE(pref, tmp_offset); tmp_offset += 2
+            label_info = read_domain(buf, offset + delta)
+            clen = write_domain(tmp_buf, label_info["name"], tmp_offset,
+                    False)
+            result = tmp_buf.toString("base64", 0, clen)
+        elif data_type in [RECORD_TYPES.SOA]:
+            label_info = read_domain(buf, offset)
+            clen = write_domain(tmp_buf, label_info["name"], tmp_offset,
+                    False)
+            tmp_offset = clen
+            label_info = read_domain(buf, label_info["offset"])
+            clen = write_domain(tmp_buf, label_info["name"], clen, False)
+            tmp_offset = clen
+            extra_len = 5*4
+            buf.copy(tmp_buf, tmp_offset, label_info["offset"],
+                    label_info["offset"] + extra_len)
+            result = tmp_buf.toString("base64", 0,
+                    tmp_offset + extra_len)
+        else:
+            result = buf.toString("base64", offset, offset + rdlen)
+        return result
+
+    def write_buf(self, buf):
+        """Output the message to a buf suitable to socket send"""
+        offset = 0
+        offset = self.write_headers(buf, offset)
+        offset = self.write_records(buf, offset)
+        return offset
+
+    def write_headers(self, buf, offset):
+        buf.writeUInt16BE(self.id, offset); offset += 2
+        buf.writeUInt16BE(self.flags, offset); offset += 2
+        return offset
+
+    def write_records(self, buf, offset):
+        buf.writeUInt16BE(len(self.question), offset); offset += 2
+        buf.writeUInt16BE(len(self.answer), offset); offset += 2
+        buf.writeUInt16BE(len(self.authority), offset); offset += 2
+        buf.writeUInt16BE(len(self.additional), offset); offset += 2
+
+        offset = self.write_questions(buf, self.question, offset)
+        offset = self.write_resource_record(buf, self.answer, offset)
+        offset = self.write_resource_record(buf, self.authority, offset)
+        offset = self.write_resource_record(buf, self.additional, offset)
+        return offset
+
+    def write_one_question(self, buf, data, offset):
+        offset = write_domain(buf, data["name"], offset)
+        buf.writeUInt16BE(data["type"], offset); offset += 2
+        buf.writeUInt16BE(data["class"], offset); offset += 2
+        return offset
+
+    def write_questions(self, buf, questions, offset):
+        for data in questions:
+            offset = self.write_one_question(buf, data, offset)
+        return offset
+
+    def write_resource_record(self, buf, resource_record, offset):
+        for rr in resource_record:
+            offset = self.write_one_question(buf, rr, offset)
+            buf.writeUInt32BE(rr["ttl"], offset); offset += 4
+            # FIXME: rdata can be label compressed too, decode like read
+            wlen = buf.write(rr["rdata"], offset + 2, "base64")
+            buf.writeUInt16BE(wlen, offset); offset += 2
+            offset += wlen
+        return offset
+
+@external
+class EventEmitter:
+    pass
+class DnsLookupError(DnsError):
+    def __init__(self, msg):
+        DnsError.__init__(self, msg)
+        self.name = "DnsLookupError"
+
+class DnsUDPClient(EventEmitter):
+    """Query remote dns server to get a response
+        Emit Events:
+            "resolved",
+            "timeout"
+        kinda heavy to create an object for each query
+    """
+    def __init__(self, options):
+        self.options = options
+        self.timeout = 10000 # in sec
+        self.timeout_id = -1
+        self.client = None
+
+    def lookup(self, msg):
+        """msg: DnsMessage, or Buffer"""
+        client = dgram.createSocket("udp4")
+        self.client = client
+        client.unref()
+        def _on_msg(b, r):
+            self._on_message(b, r)
+        def _on_error(err):
+            log.error("Err on DnsUDPClient lookup:", err)
+        client.on("message", _on_msg)
+        client.on("error", _on_error)
+
+        if isinstance(msg, Buffer):
+            buf = msg
+            offset = buf.length
+        elif isinstance(msg, DnsMessage):
+            buf = Buffer(BUFFER_SIZE)
+            offset = msg.write_buf(buf)
+        else:
+            tp = typeof msg
+            raise DnsLookupError("Unknown msg type when lookup(): " + tp)
+
+        #console.warn(buf, offset, DNS_PORT, self.options["dns_host"])
+        client.send(buf, 0, offset, DNS_PORT, self.options["dns_host"])
+        def _on_kill_me_timeout():
+            self.kill_me()
+        self.timeout_id = setTimeout(_on_kill_me_timeout, self.timeout)
+
+    def _on_message(self, buf, remote_info):
+        nonlocal BUFFER_SIZE
+        #console.warn("DnsUDPClient._on_message()")
+        if buf.length > BUFFER_SIZE:
+            BUFFER_SIZE = buf.length
+
+        self.emit("resolved", buf)
+        if self.timeout_id != -1:
+            clearTimeout(self.timeout_id)
+        self.client.close()
+
+    def kill_me(self):
+        """on timeout, close the udp socket"""
+        #console.warn("kill_me()")
+        self.client.close()
+        self.timeout_id = -1
+        self.emit("timeout")
+
+class DnsProxy(EventEmitter):
+    def __init__(self, options, router=None):
+        """Router is used to route local name to ip
+            options:
+                listen_port: dns proxy port. default: 53
+                listen_address: dns proxy address. default: 0.0.0.0
+                dns_host: remote DNS server we do real DNS lookup.
+                          default: 8.8.8.8
+                dns_rate_limit: dns lookup/second rate limit
+            router: a router class to direct domain name to fake ip.
+                    Should have a method router.lookup(domain_name)
+                    return an ip address or None
+            Events:
+                "listening": emit when the server has been bound to port
+
+        """
+        if router is None:
+            router = BaseRouter()
+        self.timeout = 30 * 1000 # milliseconds
+        self.router = router
+        self.banned = {}
+        self.banned_record_types = ["ANY", "TXT"]
+        if not options["dns_host"]:
+            options["dns_host"] = DNS_DEFAULT_HOST
+        self.options = options
+        rate_limit = self.options["dns_rate_limit"] or DNS_RATE_LIMIT
+        self.rate_limiter = lutils.createRateLimiter({
+            "rate-limit": rate_limit,
+            })
+        self.rate_limiter.set_name("DNS Proxy")
+
+        self.query_map = {}
+        self.usock = dgram.createSocket("udp4")
+
+        def _on_message(b, r):
+            self._on_dns_message(b, r)
+        def _on_error(err):
+            self._on_dns_error(err)
+        def _on_listening():
+            self._on_dns_listening()
+        self.usock.on("message", _on_message)
+        self.usock.on("listening", _on_listening)
+        self.usock.on("error", _on_error)
+
+    def _on_dns_message(self, buf, remote_info):
+        #console.log("remote info:", remote_info)
+        raddress = remote_info.address
+        if self.rate_limiter.over_limit(raddress) or self.banned[raddress]:
+            return
+        nonlocal BUFFER_SIZE
+        if buf.length > BUFFER_SIZE:
+            BUFFER_SIZE = buf.length
+
+        rport = remote_info.port
+        try:
+            dns_msg = DnsMessage(buf)
+        except as e:
+            log.error("DNS Proxy DoS attack: decode message failed:", e,
+                    raddress)
+            self.rate_limiter.add_deny(raddress)
+            return
+
+        # Drop all the DNS.ANY questions. It's just stupid
+        for q in dns_msg.question:
+            for btype in self.banned_record_types:
+                if q["type"] == RECORD_TYPES[btype]:
+                    self.banned[raddress] = True
+                    log.warn("DNS Proxy DoS (%s):", btype, q, raddress)
+                    return
+            if q["class"] is not DNS_CLASSES.IN:
+                self.banned[raddress] = True
+                log.warn("DNS Proxy DoS bad class:", q, raddress)
+                return
+
+        ret = self.local_router_lookup(dns_msg, rport, raddress)
+        if ret is False:
+            if self.options["dns_relay"]:
+                self.remote_lookup(buf, dns_msg, rport, raddress)
+            else:
+                self.answer_refused(dns_msg, rport, raddress)
+
+    def local_router_lookup(self, dns_msg, rport, raddress):
+        """Short cut, if only an "A" query for routed domains,
+           send out a "A" response immediately
+        """
+        ret = False
+        ip = None
+        for q in dns_msg.question:
+            rec_name = q["name"]
+            ip = self.router.lookup(rec_name)
+            if (q["type"] in [RECORD_TYPES.A] and ip is not None):
+                ret = True
+            else:
+                ret = False
+                break
+        if ret is True:
+            send_msg = self.create_a_message(dns_msg.id, rec_name, ip)
+            send_msg.question = dns_msg.question
+            log.debug("DNS local router:", send_msg.answer[0]["name"], raddress)
+            buf = Buffer(BUFFER_SIZE)
+            length = send_msg.write_buf(buf)
+            self.send_response(buf, length, rport, raddress)
+        return ret
+
+    def remote_lookup(self, buf, dns_msg, rport, raddress):
+        """query on remote DNS server"""
+        log.debug("DNS remote lookup:", dns_msg.question[0], raddress)
+        dns_client = DnsUDPClient(self.options)
+        query_key = dns_msg.id + raddress + rport
+        d = Date()
+        time_stamp = d.getTime()
+        self.query_map[query_key] = [dns_client, time_stamp]
+        def _on_resolved(buf):
+            self.handle_lookup_result(buf, rport, raddress)
+        dns_client.on("resolved", _on_resolved)
+        dns_client.lookup(dns_msg)
+
+    def _on_dns_error(self, err):
+        log.error("Err on dns proxy:", err)
+
+    def _on_dns_listening(self):
+        addr = self.usock.address()
+        log.info("DNS proxy listens on %s:%d", addr.address, addr.port)
+        self.emit("listening")
+
+    def create_a_message(self, msg_id, name, ip):
+        """Create a DnsMessage with type "A" query result"""
+        msg = DnsMessage()
+        msg.id = msg_id
+        msg.flags = DNS_FLAGS.QR | DNS_FLAGS.AA
+        msg.answer = [{
+            "name": name,
+            "type": RECORD_TYPES.A,
+            "class": DNS_CLASSES.IN,
+            "ttl": DEFAULT_TTL,
+            "rdata": encode_ip(ip)
+            }]
+        return msg
+
+    def handle_lookup_result(self, buf, rport, raddress):
+        """process remote real dns lookup response"""
+        msg = DnsMessage(buf)
+        changed = False
+        aliases = {}
+
+        for records in [msg.answer, msg.authority, msg.additional]:
+            for record in records:
+                rec_name = record["name"]
+                if record["type"] in [RECORD_TYPES.A, RECORD_TYPES.AAAA]:
+                    ip = self.router.lookup(rec_name)
+                    if ip is None and rec_name in aliases:
+                        ip = aliases[rec_name]
+                    if ip is not None:
+                        record["rdata"] = encode_ip(ip)
+                        changed = True
+                if record["type"] in [RECORD_TYPES.CNAME, RECORD_TYPES.DNAME]:
+                    cname = decode_base64_label(record["rdata"])
+                    ip = self.router.lookup(rec_name)
+                    if ip is not None:
+                        aliases[cname] = ip
+                    elif rec_name in aliases:
+                        aliases[cname] = aliases[rec_name]
+        #changed = True; console.warn("changed:", changed)
+        if changed is True:
+            buf = Buffer(BUFFER_SIZE)
+            offset = msg.write_buf(buf)
+        else:
+            offset = buf.length
+        query_key = msg.id + raddress + rport
+        d = Date()
+        time_stamp = d.getTime()
+        if time_stamp in self.query_map:
+            del self.query_map[time_stamp]
+        self.send_response(buf, offset, rport, raddress)
+
+    def answer_refused(self, dns_message, rport, raddress):
+        """Send a Refused dns answer message to the client"""
+        log.debug("DNS Refused:", dns_message.question[0], raddress)
+        send_msg = DnsMessage()
+        send_msg.id = dns_message.id
+        send_msg.flags = DNS_FLAGS.QR | DNS_RCODES["Refused"]
+        buf = Buffer(BUFFER_SIZE)
+        length = send_msg.write_buf(buf)
+        self.send_response(buf, length, rport, raddress)
+
+    def send_response(self, buf, length, rport, raddress):
+        #console.warn("send_response:", rport, raddress)
+        self.usock.send(buf, 0, length, rport, raddress)
+
+    def start(self, ip="0.0.0.0"):
+        port = self.options["listen_port"] or DNS_PORT
+        #console.warn("listen port", port)
+        if "listen_address" in self.options:
+            ip = self.options["listen_address"]
+
+        self.usock.bind(port, ip)
+        def _on_clean_interval():
+            self.clean_query_map()
+        self.clean_interval = setInterval(_on_clean_interval, 10*1000)
+
+    def clean_query_map(self):
+        """Clean up query map periodically"""
+        d = Date()
+        now = d.getTime()
+        #console.log(now/1000)
+        for k in self.query_map:
+            time_stamp = k[1]
+            if (now - time_stamp) > self.timeout:
+                del self.query_map[k]
+
+class PublicIPBox:
+    def __init__(self, domain):
+        """Get public IP of the given domain name.
+
+        @domain: can be the string "lookup" or a string of domain name
+        """
+        self.domain = domain
+        self.ip = None
+        self.check_timeout = 10*60*1000 # 10 minutes
+        self.check_iid = None # check setInterval id
+        self.start_lookup()
+
+    def _on_interval(self):
+        """lookup public IP and set it"""
+        target = self.domain
+
+        def _on_public_ip(public_ip):
+            """Update public IP"""
+            #log.debug("found public_ip:", public_ip)
+            if not public_ip:
+                log.warn("Failed to find valid public ip:",
+                        self.domain, self.ip)
+            elif public_ip != self.ip:
+                self.ip = public_ip
+                log.debug("public_ip:", self.domain, self.ip)
+
+        if target == "lookup":
+            lutils.get_public_ip(_on_public_ip)
+        else: # domain name, do dns lookup
+            def _on_dns_lookup(err, addr, fam):
+                if err:
+                    log.warn("public_update error:", err)
+                _on_public_ip(addr)
+            dns.lookup(target, _on_dns_lookup)
+
+    def start_lookup(self):
+        self._on_interval() # check immediately
+        if not self.check_iid:
+            def _on_interval():
+                self._on_interval()
+            self.check_iid = setInterval(_on_interval, self.check_timeout)
+
+def createPublicIPBox(domain_name):
+    ipbox = PublicIPBox(domain_name)
+    return ipbox
+
+class BaseRouter:
+    """Route domain address to known ip:
+        www.sohu.com ==> 127.0.0.1
+    """
+    def __init__(self, address_map):
+        self.address_map = address_map
+        self.public_ip_box = None
+
+
+    def set_public_ip_box(self, public_ip_box):
+        self.public_ip_box = public_ip_box
+
+    def set(self, domain, ip):
+        """Add a new domain => ip route"""
+        self.address_map[domain] = ip
+
+    def lookup(self, address):
+        """lookup ip of a given domain name"""
+        result = None
+        if address in self.address_map:
+            result = self.address_map[address]
+
+        # do target replace
+        ip_box = self.public_ip_box
+        if ip_box is not None and result == ip_box.domain:
+            result = ip_box.ip
+        return result
+
+def createServer(options, router):
+    s = DnsProxy(options, router)
+    return s
+
+def createBaseRouter(address_map):
+    r = BaseRouter(address_map)
+    return r
+
+class DnsResolver(EventEmitter):
+    """Lookup a domain ip use a given DNS server"""
+    def __init__(self, dns_server, dns_port):
+        self.server = dns_server
+        self.port = dns_port or DNS_PORT
+        self.timeout = 10000 # in sec
+        self.id_count = 1 # uniq dns message id
+
+    def lookup(self, domain, callback, err_callback):
+        """Lookup ip of a domain
+        @callback: func(name, ip)
+        """
+        client = dgram.createSocket("udp4")
+        client.unref()
+
+        # match callback to DNS ID for lookup result
+        msg_id = self.id_count
+        self.id_count += 1
+
+        def _on_msg(b, r):
+            self._on_message(b, r, callback)
+            clearTimeout(timeout_id)
+            client.close()
+        def _on_error(err):
+            clearTimeout(timeout_id)
+            err.message += ": " + domain
+            if err_callback:
+                err_callback(err)
+            else:
+                self.emit("error", err)
+        client.on("message", _on_msg)
+        client.on("error", _on_error)
+
+        msg = self.create_a_question(msg_id, domain)
+        buf = Buffer(BUFFER_SIZE)
+        offset = msg.write_buf(buf)
+
+        log.debug("DNS lookup of %s @%s:%d", domain, self.server, self.port)
+        client.send(buf, 0, offset, self.port, self.server)
+
+        def _on_kill_me_timeout():
+            client.close()
+            err = DnsLookupError("timeout: " + domain)
+            log.debug(err)
+            if err_callback:
+                err_callback(err)
+            else:
+                self.emit("error", err)
+        timeout_id = setTimeout(_on_kill_me_timeout, self.timeout)
+
+    def create_a_question(self, msg_id, name):
+        """Create a DnsMessage with type "A" query question"""
+        msg = DnsMessage()
+        msg.id = msg_id
+
+        msg.flags = DNS_FLAGS.RD
+        msg.question = [{
+            "name": name,
+            "type": RECORD_TYPES.A,
+            "class": DNS_CLASSES.IN,
+            }]
+        return msg
+
+    def ip_from_a_message(self, dns_msg):
+        """retrieve lookup result ip from a DNS message"""
+        rec = None
+        for ans in dns_msg.answer:
+            if ans["type"] == RECORD_TYPES.A:
+                rec = ans
+                break
+        if rec is None:
+            return None
+        ip = decode_ip(rec["rdata"])
+        return {"name": rec["name"], "ip": ip}
+
+    def _on_message(self, buf, remote_info, callback):
+        """receive a DNS query result"""
+        nonlocal BUFFER_SIZE
+        #console.warn("DnsUDPClient._on_message()")
+        if buf.length > BUFFER_SIZE:
+            BUFFER_SIZE = buf.length
+
+        msg = DnsMessage(buf)
+        name = None
+        ip = None
+        result = self.ip_from_a_message(msg)
+        if result is not None:
+            name = result["name"]
+            ip = result["ip"]
+
+        if callback:
+            callback(name, ip)
+
+        self.emit("resolved", name, ip)
+
+def createDnsResolver(address, port):
+    s = DnsResolver(address, port)
+    return s
+
+def main():
+    """Run test"""
+    log.set_level(log.DEBUG)
+    router = BaseRouter({"www.sohu.com": "127.0.0.1"})
+    options = {"dns_host": "8.8.8.8", "listen_port": 2000}
+    DnsProxy(options, router).start()
+
+    childp = require("child_process")
+    qs = ["www.sohu.com", "www.sohu.com mx", "fhk.a.sohu.com"]
+    cmd_prefix = "/usr/bin/dig @127.0.0.1 -p 2000 "
+    def rerun(error, stdout, stderr): # recursive exec dns query cmd
+        if stdout: console.log(stdout)
+        if error: console.log(error)
+        if qs.length > 0:
+            cmd = cmd_prefix + qs.pop()
+            console.log("$", cmd)
+            childp.exec(cmd, rerun)
+        #else: process.exit(code=0)
+    rerun()
+
+    # test dns resolver
+    dr = DnsResolver("156.154.71.1")
+    def rcb(n, i):
+        console.log("resolver callback", n, i)
+    dr.lookup("h1.edu.bj.ie.sogou.com", rcb)
+    dr.lookup("h2.edu.bj.ie.sogou.com")
+    dr.on("resolved", rcb)
+
+if require.main is JS("module"):
+    main()
+
+exports.DnsProxy = DnsProxy
+exports.BaseRouter = BaseRouter
+exports.createDnsResolver = createDnsResolver
+exports.createServer = createServer
+exports.createBaseRouter = createBaseRouter
+exports.createPublicIPBox = createPublicIPBox

--- a/dns-reverse-proxy/droxy.py
+++ b/dns-reverse-proxy/droxy.py
@@ -1,0 +1,352 @@
+# vim:fileencoding=utf-8:sw=4:et:syntax=python
+
+path = require("path")
+fs = require("fs")
+net = require("net")
+
+dnsproxy = require("./dns-proxy")
+reversesogouproxy = require("./reverse-sogou-proxy")
+lutils = require("./lutils")
+log = lutils.logger
+
+appname = "ub.uku.droxy"
+
+def load_resolv_conf():
+    """Parse /etc/resolv.conf and return 1st dns host found"""
+    fname = "/etc/resolv.conf"
+    data = fs.readFileSync(fname, "utf-8")
+    lines = data.split("\n")
+    dns_host = None
+    for line in lines:
+        if line[0] == "#":continue
+        parts = line.split(" ")
+        if parts[0].toLowerCase() == "nameserver":
+            dns_host = parts[1]
+            break
+    return dns_host
+
+def load_dns_map(target_ip):
+    """Create a DNS router to map a list of domain name to a target ip"""
+    if not target_ip:
+        target_ip = "127.0.0.1"
+    domain_map = lutils.fetch_user_domain()
+    dmap = {}
+    for domain in Object.keys(domain_map):
+        dmap[domain] = target_ip
+
+    # our proxy test server
+    dmap["httpbin.org"] = target_ip
+    #log.debug(dmap)
+    return dmap
+
+def load_router_from_file(fname, dns_map):
+    """Load domain -> ip map from a JSON file"""
+    if not (fname and fs.existsSync(fname)):
+        log.error("extra router file not found:", fname)
+        process.exit(2)
+    data = fs.readFileSync(fname, "utf-8")
+    # fix loose JSON: extra comma before }]
+    data = data.replace(/,(\s*[\}|\]])/g, '$1')
+    rdict = JSON.parse(data)
+    for k in Object.keys(rdict):
+        dns_map[k] = rdict[k]
+
+def load_extra_url_list(fname):
+    """Add extra url list to the shared urls
+    The input file is a JSON file with a single array of url pattern strings
+    """
+    if not (fname and fs.existsSync(fname)):
+        log.error("extra url filter file not found:", fname)
+        process.exit(2)
+
+    data = fs.readFileSync(fname, "utf-8")
+    data = data.replace(/,(\s*[\}|\]])/g, '$1')
+    url_list = JSON.parse(data)
+
+    shared_urls = require("../shared/urls.js")
+    url_regex = shared_urls.urls2regexs(url_list)
+    for u in url_list:
+        shared_urls.url_list.push(u)
+    for r in url_regex:
+        shared_urls.url_regex_list.push(r)
+
+def drop_root(options):
+    """change root and drop root priviledge"""
+    try:
+        chroot = require("chroot")
+        rdir = options["chroot_dir"]
+        ruser = options["run_as"]
+        chroot(rdir, ruser)
+        for k in Object.keys(process.env):
+            del process.env[k]
+        process.env["PWD"] = "/"
+        process.env["HOME"] = "/"
+        log.info('changed root to "%s" and user to "%s"', rdir, ruser)
+
+        # see if resolv.conf exists for getaddrinfo()
+        resolv_path = "/etc/resolv.conf"
+        try:
+            _ = fs.openSync(resolv_path, "r")
+            fs.close(_)
+        except as e:
+            log.warn("WARN: %s is not reachable", resolv_path)
+    except as e:
+        log.warn("WARN: Failed to chroot:", e)
+
+server_count = 0
+def run_servers(argv):
+    if argv["extra_url_list"]:
+        load_extra_url_list(argv["extra_url_list"])
+
+    # setup dns proxy
+    dns_options = {
+            "listen_address": "0.0.0.0",
+            "listen_port": argv["dns_port"],
+            "dns_relay": not argv["dns_no_relay"],
+            "dns_rate_limit": int(argv["dns_rate_limit"]),
+            }
+    if argv["ip"]:
+        dns_options["listen_address"] = argv["ip"]
+    if argv["dns_host"]:
+        dns_options["dns_host"] = argv["dns_host"]
+    if not dns_options["dns_host"]:
+        dns_options["dns_host"] = load_resolv_conf()
+    log.debug("dns_options:", dns_options)
+
+    # setup http proxy
+    sogou_proxy_options = {
+            "listen_port": argv["http_port"],
+            "listen_address": "127.0.0.1",
+            "sogou_dns": argv["sogou_dns"],
+            "sogou_network": argv["sogou_network"],
+            "http_rate_limit": int(argv["http_rate_limit"]),
+            }
+    if argv["ip"]:
+        sogou_proxy_options["listen_address"] = argv["ip"]
+    if argv["ext_ip"]:
+        sogou_proxy_options["external_ip"] = argv["ext_ip"]
+
+    # https proxy
+    #sogou_proxy_options_s = JSON.parse(JSON.stringify(sogou_proxy_options))
+    #sogou_proxy_options_s["listen_port"] = 443
+    #log.debug("sogou_proxy_options_s:", sogou_proxy_options_s)
+    log.debug("sogou_proxy_options:", sogou_proxy_options)
+
+    target_ip = argv["ext_ip"] or sogou_proxy_options["listen_address"]
+    dns_map = load_dns_map(target_ip)
+
+    if argv["dns_extra_router"]:
+        load_router_from_file(argv["dns_extra_router"], dns_map)
+    #log.debug("dns_map:", dns_map)
+
+    # now we are set, create servers
+    drouter = dnsproxy.createBaseRouter(dns_map)
+
+    dproxy = dnsproxy.createServer(dns_options, drouter)
+    sproxy = reversesogouproxy.createServer(sogou_proxy_options)
+
+    # if need lookup externel IP
+    if not (net.isIPv4(target_ip) or net.isIPv6(target_ip)):
+        ipbox = dnsproxy.createPublicIPBox(target_ip)
+        drouter.set_public_ip_box(ipbox)
+        sproxy.set_public_ip_box(ipbox)
+
+    # drop root priviledge if run as root
+    def _on_listen():
+        nonlocal server_count
+        server_count += 1
+        if server_count >= 2:
+            drop_root(argv)
+
+    dproxy.on("listening", _on_listen)
+    sproxy.on("listening", _on_listen)
+
+    dproxy.start()
+    sproxy.start()
+
+def expand_user(txt):
+    """Expand tild (~/) to user home directory"""
+    if txt == "~" or txt[:2] == "~/":
+        txt = process.env.HOME + txt.substr(1)
+    return txt
+
+def fix_keys(dobj):
+    """replace "-" in dict keys to "_" """
+    for k in Object.keys(dobj):
+        if k[0] == "#":
+            del dobj[k]
+        elif "-" in k:
+            nk = k.replace(/-/g, "_")
+            dobj[nk] = dobj[k]
+            del dobj[k]
+
+def load_config(argv):
+    """Load config file and update argv"""
+    cfile = argv.config
+    cfile = expand_user(cfile)
+    if not (cfile and fs.existsSync(cfile)):
+        return
+
+    # load config file as a JSON file
+    data = fs.readFileSync(cfile, "utf-8")
+    # naiive fix dict with unquoted keys
+    data = data.replace(RegExp('([\'"])?(#?[-_a-zA-Z0-9]+)([\'"])?:', "g"),
+            '"$2": ')
+    # extra comma before }]
+    data = data.replace(/,(\s*[\}|\]])/g, '$1')
+    log.debug("config data:", data)
+
+    cdict = JSON.parse(data)
+    fix_keys(cdict)
+
+    for k in Object.keys(cdict):
+        argv[k] = cdict[k]
+
+def parse_args():
+    """Cmdline argument parser"""
+    optimist = require("optimist")
+
+    # config file location. Borrow from blender
+    # http://wiki.blender.org/index.php/Doc:2.6/Manual/Introduction/Installing_Blender/DirectoryLayout
+    os = require("os")
+    platform = os.platform()
+    if platform == "win32":
+        config_dir = "AppData"
+    elif platform == "darwin": # Mac OSX
+        config_dir = "Library/:Application Support"
+    else:
+        config_dir = ".config"
+    config_path = path.join(expand_user("~/"), config_dir, appname,
+            "config.json")
+
+    cmd_args = {
+            "ip": {
+                "description": "local IP address to listen on",
+                "default": "0.0.0.0",
+                },
+            "dns-host": {
+                "description"
+                    : "remote dns host. default: first in /etc/resolv.conf",
+                },
+            "sogou-dns": {
+                "description"
+                    : "DNS used to lookup IP of sogou proxy servers",
+                "default": None,
+                },
+            "sogou-network": {
+                "description"
+                    : 'choose between "edu" and "dxt"',
+                "default": None,
+                },
+            "extra-url-list": {
+                "description"
+                    : "load extra url redirect list from a JSON file",
+                },
+            /* Advanced usage
+            "dns-extra-router": {
+                "description"
+                    : "load extra domain -> ip map for DNS from a JSON file",
+                },
+            */
+            "ext-ip": {
+                "description": \
+                    'for public DNS, the DNS proxy route to the given ' +
+                    'public IP. If set to "lookup", try to find the ' +
+                    'public IP through http://httpbin.org/ip. If a ' +
+                    'domain name is given, the IP will be lookup ' +
+                    'through DNS',
+                "default": None,
+                },
+            "dns-no-relay": {
+                "description"
+                    : "don't relay un-routed domain query to upstream DNS",
+                "boolean": True,
+                },
+            "dns-rate-limit": {
+                "description"
+                    : "DNS query rate limit per sec per IP. -1 = no limit",
+                "default": 25,
+                },
+            "dns-port": {
+                "description"
+                    : "local port for the DNS proxy to listen on. " +
+                      "Useful with port forward",
+                "default": 53,
+                },
+            "http-port": {
+                "description"
+                    : "local port for the HTTP proxy to listen on. " +
+                      "Useful with port forward",
+                "default": 80,
+                },
+            "http-rate-limit": {
+                "description"
+                    : "HTTP proxy rate limit per sec per IP. -1 = no limit",
+                "default": 20,
+                },
+            "run-as": {
+                "description": "run as unpriviledged user (sudo/root)",
+                "default": "nobody",
+                },
+            "chroot-dir": {
+                "description": "chroot to given directory (sudo/root). " +
+                    "Should copy /etc/resolv.conf to " +
+                    "/newroot/etc/resolv.conf and make it readable if needed",
+                "default": "/var/chroot/droxy",
+                },
+            "config": {
+                "description": "load the given configuration file",
+                "default": config_path,
+                "alias": "c",
+                },
+            "debug": {
+                "description": "debug mode",
+                "boolean": True,
+                "alias": "D",
+                },
+            "help": {
+                "alias": "h",
+                "description": "print help message",
+                "boolean": True,
+                },
+            }
+
+    opt = optimist.usage(
+        "DNS Reverse Proxy(droxy) server with unblock-youku\n" +
+        "Usage:\n\t$0 [--options]", cmd_args).wrap(78)
+
+    argv = opt.argv
+    # remove alias entries
+    for k in Object.keys(cmd_args):
+        item = cmd_args[k]
+        akey = item["alias"]
+        if akey:
+            del argv[akey]
+    fix_keys(argv)
+
+    if argv["sogou_network"]:
+        sd = argv["sogou_network"]
+        if not (sd == "dxt" or sd == "edu"):
+            opt.showHelp()
+            log.error('*** Error: Bad value for option --sogou-network %s',
+                    sd)
+            process.exit(code=2)
+
+    if argv.help:
+        opt.showHelp()
+        process.exit(code=0)
+    return argv
+
+def main():
+    argv = parse_args()
+    if argv.debug:
+        log.set_level(log.DEBUG)
+        log.debug("argv:", argv)
+    load_config(argv)
+    log.debug("with config:", argv)
+    run_servers(argv)
+
+if require.main is JS("module"):
+    main()
+
+exports.main = main

--- a/dns-reverse-proxy/lutils.py
+++ b/dns-reverse-proxy/lutils.py
@@ -1,0 +1,389 @@
+# vim:fileencoding=utf-8:sw=4:et:syntax=python
+"""Local utility functions and classes"""
+
+SOCKET_TIMEOUT = 10*1000
+UAGENT_CHROME = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) AppleWebKit/537.11 (KHTML, like Gecko) Chrome/23.0.1271.95 Safari/537.11"
+RATE_LIMITER_DENY_TIMEOUT = 5*60 # in seconds
+
+http = require('http')
+net = require("net")
+url = require("url")
+dns = require("dns")
+EventEmitter = require("events").EventEmitter
+shared_urls = require('../shared/urls')
+shared_tools = require('../shared/tools')
+sogou = require('../shared/sogou')
+string_starts_with = shared_tools.string_starts_with;
+to_title_case = shared_tools.to_title_case
+
+# Possible IP prefixes of sogou proxy
+SOGOU_IPS = ["121.195.", "123.126.", "220.181."]
+
+class Logger:
+    def __init__(self, level=None):
+        # level from python logging.__init__
+        self.CRITICAL = 50
+        self.ERROR = 40
+        self.WARN = 30
+        self.INFO = 20
+        self.DEBUG = 10
+        self.NOTSET = 0
+
+        if level is None:
+            level = self.INFO
+        self.level = level
+
+    def set_level(self, level):
+        self.level = level
+
+    def _log(self, level, *args):
+        if level >= self.level:
+            console.log(*args)
+    def msg(self, *args): # force message?
+        self._log(self.NOTSET, *args)
+    def debug(self, *args):
+        self._log(self.DEBUG, *args)
+    def info(self, *args):
+        self._log(self.INFO, *args)
+    def log(self, *args):
+        self.info(*args)
+    def warn(self, *args):
+        self._log(self.WARN, *args)
+    def error(self, *args):
+        self._log(self.ERROR, *args)
+    def critical(self, *args):
+        self._log(self.CRITICAL, *args)
+logger = Logger()
+
+def add_sogou_headers(req_headers, hostname):
+    sogou_auth = sogou.new_sogou_auth_str()
+    timestamp = Math.round(Date.now() / 1000).toString(16)
+    sogou_tag = sogou.compute_sogou_tag(timestamp, hostname)
+
+    req_headers['X-Sogou-Auth'] = sogou_auth
+    req_headers['X-Sogou-Timestamp'] = timestamp
+    req_headers['X-Sogou-Tag'] = sogou_tag
+    random_ip = shared_tools.new_random_ip()
+    req_headers['X-Forwarded-For'] = random_ip
+    req_headers['Client-IP'] = random_ip
+
+class URLMatch:
+    def __init__(self, url_list, prefix_len):
+        """Speedup regex matching to a long list of urls
+
+        use prefix of the regex pattern as keys to category the url list
+        into groups
+        """
+        self.prefix_len = prefix_len or 15
+        self.regex_map = self.create_map(url_list, self.prefix_len)
+
+    def create_map(self, url_list, prefix_len):
+        """create a map between the prefix of urls to regex list"""
+        url_map = {}
+        for url in url_list:
+            k = url[0:prefix_len]
+            if k.indexOf("*") >= 0:
+                k = "any"
+            val_list = url_map[k] or []
+            if val_list.length is 0:
+                url_map[k] = val_list
+            val_list.push(url)
+        #logger.debug("url_map:", url_map)
+        regex_map = {}
+        for k in Object.keys(url_map):
+            regex_list = shared_urls.urls2regexs(url_map[k])
+            regex_map[k] = regex_list
+        return regex_map
+
+    def test(self, url):
+        k = url[0:self.prefix_len]
+        regex_list = self.regex_map[k] or self.regex_map["any"]
+        ret = False
+        for pattern in regex_list:
+            if pattern.test(url):
+                ret = True
+                break
+        return ret
+
+
+url_match = None
+def is_valid_url(target_url):
+    nonlocal url_match
+    if url_match is None:
+        url_match = URLMatch(shared_urls.url_list)
+    for white_pattern in shared_urls.url_regex_whitelist:
+        if white_pattern.test(target_url):
+            return False
+    if url_match.test(target_url):
+        return True
+    if string_starts_with(target_url, 'http://httpbin.org'):
+        return True
+    return False
+
+class SogouManager(EventEmitter):
+    """Provide active Sogou proxy"""
+    def __init__(self, dns_resolver):
+        """
+        @dns_resolver : an optional DnsResolver to lookup sogou server IP
+        """
+        self.dns_resolver = dns_resolver
+        self.sogou_network = None
+
+    def new_proxy_address(self):
+        new_addr = sogou.new_sogou_proxy_addr();
+        if self.sogou_network:
+            good_net = new_addr.indexOf(self.sogou_network) >= 0
+            while not good_net:
+                new_addr = sogou.new_sogou_proxy_addr();
+                good_net = new_addr.indexOf(self.sogou_network) >= 0
+        return new_addr
+
+    def renew_sogou_server(self, depth=0):
+        new_addr = self.new_proxy_address()
+
+        new_ip = None
+
+        # use a give DNS to lookup ip of sogou server
+        if self.dns_resolver and not net.isIPv4(new_addr):
+            def _lookup_cb(name, ip):
+                addr_info = {
+                        "address": name,
+                        "ip": ip
+                        }
+                self.check_sogou_server(addr_info, depth)
+            def _err_cb(err):
+                self.emit("error", err)
+
+            self.dns_resolver.lookup(new_addr, _lookup_cb, _err_cb)
+        else:
+            addr_info = {"address": new_addr}
+            self.check_sogou_server(addr_info, depth)
+
+    def _on_check_sogou_success(self, addr_info):
+        """Called when sogou server check success"""
+        self.emit("renew-address", addr_info)
+
+        # check if ISP DNS hijacked sogou proxy domain name
+        domain = addr_info["address"]
+        def _on_lookup(err, addr, family):
+            valid = False
+            for sgip in SOGOU_IPS:
+                if addr.indexOf(sgip) is 0:
+                    valid = True
+                    break
+            if not valid:
+                logger.warn("WARN: sogou IP (%s -> %s) seems invalid",
+                        domain, addr)
+        if not addr_info["ip"]:
+            dns.lookup(addr_info["address"], 4, _on_lookup)
+        else:
+            _on_lookup(None, addr_info["ip"], None)
+
+    def check_sogou_server(self, addr_info, depth=0):
+        """check validity of proxy.
+        emit "renew-address" on success
+        """
+        if depth >= 10:
+            self.emit("renew-address", addr_info)
+            return
+
+        new_addr = addr_info["address"]
+        new_ip = addr_info["ip"]
+
+        headers = {
+            "Accept-Language": "en-US,en;q=0.8,zh-CN;q=0.6,zh;q=0.4,zh-TW;q=0.2",
+            "Accept-Encoding": "deflate",
+            "Accept": "text/html,application/xhtml+xml," +
+                "application/xml;q=0.9,*/*;q=0.8",
+            "User-Agent": UAGENT_CHROME,
+            "Accept-Charset": "gb18030,utf-8;q=0.7,*;q=0.3"
+        }
+
+        options = {
+            host: new_ip or new_addr,
+            headers: headers,
+        }
+        logger.debug("check sogou adderss:", addr_info, options.host)
+
+        def on_response (res):
+            if 400 == res.statusCode:
+                self._on_check_sogou_success(addr_info)
+            else:
+                logger.error('[ub.uku.js] statusCode for %s is unexpected: %d',
+                    new_addr, res.statusCode)
+                self.renew_sogou_server(depth + 1)
+        req = http.request(options, on_response)
+
+        # http://goo.gl/G2CoU
+        def on_socket(socket):
+            def on_socket_timeout():
+                req.abort()
+                logger.error('[ub.uku.js] Timeout for %s. Aborted.', new_addr)
+            socket.setTimeout(SOCKET_TIMEOUT, on_socket_timeout)
+        req.on('socket', on_socket)
+
+        def on_error(err):
+            logger.error('[ub.uku.js] Error when testing %s: %s', new_addr, err)
+            self.renew_sogou_server(depth + 1);
+        req.on('error', on_error)
+        req.end()
+
+class RateLimiter:
+    """rate limiter
+       Limit access rate the a server per client. Prevent all kind of DDoS
+    """
+    def __init__(self, options):
+        """
+            options:
+                rate-limit: access/sec
+                deny-timeout: timeout for reactive on denied IP
+        """
+        self.options = options
+        self.name = None
+        self.deny_timeout = RATE_LIMITER_DENY_TIMEOUT * 1000 # millisec
+        if options["deny-timeout"]:
+            self.deny_timeout = options["deny-timeout"] * 1000
+        self.interval_reset = None
+        self.access_counts = {}
+        self.deny_map = {}
+        self.start()
+
+    def set_name(self, name):
+        self.name = name
+
+    def _do_reset(self):
+        """Reset rate count and deny queue"""
+        self.access_counts = {} # checking for empty creates more garbage
+
+        now = Date.now()
+        for k in Object.keys(self.deny_map):
+            time_stamp = self.deny_map[k]
+            if now > time_stamp:
+                del self.deny_map[k]
+
+    def over_limit(self, saddr):
+        """Check if the rate limit is over for a source address"""
+        if self.options["rate-limit"] < 0:
+            return False # no limit
+
+        if self.deny_map[saddr]:
+            return True
+
+        ret = False
+        ac_count = self.access_counts[saddr] or 0
+        ac_count += 1
+        self.access_counts[saddr] = ac_count
+        if ac_count > self.options["rate-limit"]:
+            msg = "DoS Flood Attack:"
+            if self.name is not None:
+                msg = self.name + " " + msg
+            logger.warn(msg, saddr)
+            ret = True
+            self.add_deny(saddr)
+        return ret
+
+    def add_deny(self, saddr):
+        """Add a source address to the deny map"""
+        self.deny_map[saddr] = Date.now() + self.deny_timeout
+        if self.access_counts[saddr]:
+            del self.access_counts[saddr]
+
+    def start(self):
+        """start the periodic check"""
+        if self.options["rate-limit"] <= 0:
+            return
+        if self.interval_reset:
+            clearInterval(self.interval_reset)
+            self.interval_reset = None
+
+        def _do_reset():
+            self._do_reset()
+        self.interval_reset = setInterval(_do_reset, 1000) # 1 sec
+
+    def stop(self):
+        """stop the periodic check"""
+        if self.interval_reset:
+            clearInterval(self.interval_reset)
+            self.interval_reset = None
+        self.access_counts = {}
+        self.deny_map = {}
+
+def createRateLimiter(options):
+    rl = RateLimiter(options)
+    return rl
+
+def createSogouManager(dns_resolver):
+    s = SogouManager(dns_resolver)
+    return s
+
+def filtered_request_headers(headers, forward_cookie):
+    ret_headers = {}
+
+    for field in Object.keys(headers):
+        if string_starts_with(field, 'proxy-'):
+            if field == 'proxy-connection':
+                ret_headers.Connection = headers['proxy-connection'];
+        elif field == 'cookie':
+            if forward_cookie:
+                ret_headers.Cookie = headers.cookie;
+        elif field == 'user-agent':
+            if (headers['user-agent'].indexOf('CloudFront') != -1 or
+                    headers['user-agent'].indexOf('CloudFlare') != -1):
+                ret_headers['User-Agent'] = UAGENT_CHROME
+            else:
+                ret_headers['User-Agent'] = headers['user-agent']
+        elif field != 'via' and (not string_starts_with(field, 'x-')):
+            # in case some servers do not recognize lower-case headers,
+            # such as hacker news
+            ret_headers[to_title_case(field)] = headers[field]
+
+    return ret_headers
+
+USER_DOMAIN_MAP = None
+def fetch_user_domain():
+    """Fetch a list of domains for the filtered ub.uku urls"""
+    nonlocal USER_DOMAIN_MAP
+    if USER_DOMAIN_MAP is not None:
+        return USER_DOMAIN_MAP
+
+    domain_dict = {}
+    for u in shared_urls.url_list:
+        # FIXME: can we do https proxy?
+        if u.indexOf("https") is 0: continue
+        parsed_url = url.parse(u)
+        hostname = parsed_url.hostname
+        if hostname and hostname not in domain_dict:
+            domain_dict[hostname] = True
+    USER_DOMAIN_MAP = domain_dict
+    return USER_DOMAIN_MAP
+
+def get_public_ip(cb):
+    """get public ip from http://httpbin.org/ip then call cb"""
+    def _on_ip_response(res):
+        content = ""
+        def _on_data(x):
+            nonlocal content
+            content += x.toString("utf-8")
+
+        def _on_end():
+            content_json = JSON.parse(content)
+            lookup_ip = content_json["origin"]
+            cb(lookup_ip)
+
+        def _on_error(err):
+            logger.error("Err on get public ip:", err)
+
+        res.on('data',_on_data)
+        res.on('end', _on_end)
+        res.on("error", _on_error)
+
+    http.get("http://httpbin.org/ip", _on_ip_response)
+
+exports.logger = logger
+exports.add_sogou_headers = add_sogou_headers
+exports.is_valid_url = is_valid_url
+exports.createSogouManager = createSogouManager
+exports.createRateLimiter = createRateLimiter
+exports.filtered_request_headers = filtered_request_headers
+exports.fetch_user_domain = fetch_user_domain
+exports.get_public_ip = get_public_ip

--- a/dns-reverse-proxy/reverse-sogou-proxy.py
+++ b/dns-reverse-proxy/reverse-sogou-proxy.py
@@ -1,0 +1,336 @@
+# vim:fileencoding=utf-8:sw=4:et:syntax=python
+# Reverse proxy server through the sogou proxy server
+
+httpProxy = require("http-proxy")
+http = require("http")
+EventEmitter = require("events").EventEmitter
+
+sogou = require('../shared/sogou')
+dns_proxy = require("./dns-proxy")
+lutils = require('./lutils')
+log = lutils.logger
+
+HTTP_RATE_LIMIT = 10 # 10 proxy request/sec
+
+MAX_ERROR_COUNT = {
+    "reset_count": 1,
+    "refuse_count": 2,
+    "timeout_count": 4,
+}
+
+@external
+class EventEmitter:
+    pass
+class ReverseSogouProxy(EventEmitter):
+    def __init__(self, options):
+        """
+            options:
+                listen_port: dns proxy port. default: 80
+                listen_address: dns proxy address. default: 0.0.0.0
+                sogou_dns: dns used to lookup sogou server ip
+                sogou_network: sogou network: "dxt" or "edu"
+                external_ip: optional public ip of a exit router
+            events:
+                "listening": emit after server has been bound to listen port
+        """
+        self.options = options
+        self.banned = {} # banned IP
+        self.sogou_renew_timeout = 10*60*1000
+        self.public_ip_box = None
+        self.request_id = 1
+
+        self.sogou_port = 80
+        self.proxy_host = "0.0.0.0"
+        self.proxy_port = 80
+        if options["listen_port"]:
+            self.proxy_port = options["listen_port"]
+        if options["listen_address"]:
+            self.proxy_host = options["listen_address"]
+
+        self.proxy = self.setup_proxy(options)
+        self.server = self.setup_server(options)
+
+        rate_limit = self.options["http_rate_limit"] or HTTP_RATE_LIMIT
+        self.rate_limiter = lutils.createRateLimiter({
+            "rate-limit": rate_limit,
+            })
+        self.rate_limiter.set_name("HTTP Proxy")
+
+        self.reset_sogou_flags()
+        self.setup_sogou_manager()
+        self.sogou_info = {"address": sogou.new_sogou_proxy_addr()}
+
+    def setup_sogou_manager(self):
+        """Manage which sogou proxy server we choose"""
+        dns_resolver = None
+        if self.options["sogou_dns"]:
+            sg_dns = self.options["sogou_dns"]
+            log.info("Sogou proxy DNS solver:", sg_dns)
+            dns_resolver = dns_proxy.createDnsResolver(sg_dns)
+        self.sogou_manager = lutils.createSogouManager(dns_resolver)
+        self.sogou_manager.sogou_network = self.options["sogou_network"]
+
+        def _on_renew_address(addr_info):
+            log.info("renewed sogou server:", addr_info)
+            self.sogou_info = addr_info
+            self.reset_sogou_flags()
+        def _on_error(err):
+            self.in_changing_sogou = -1
+            log.error("Error on renew sogou:", err)
+        self.sogou_manager.on("renew-address", _on_renew_address)
+        self.sogou_manager.on("error", _on_error)
+
+        self.renew_sogou_server(True)
+
+    def reset_sogou_flags(self):
+        """sogou server renew related flags"""
+        self.in_changing_sogou = -1 # time stamp to future upate
+        self.reset_count = 0
+        self.refuse_count = 0
+        self.timeout_count = 0
+
+    def renew_sogou_server(self, forced=False):
+        """Change to a new sogou proxy server"""
+        need_reset = forced
+        for k in Object.keys(MAX_ERROR_COUNT):
+            if getattr(self, k) > MAX_ERROR_COUNT[k]:
+                need_reset = True
+                break
+        if need_reset is False: return
+
+        if 0 < self.in_changing_sogou < Date.now():
+            return
+        self.in_changing_sogou = Date.now() + self.sogou_renew_timeout
+        log.debug("changing sogou server...")
+        self.sogou_manager.renew_sogou_server()
+
+    def setup_proxy(self, options):
+        """create the node proxy server instance"""
+        proxy = httpProxy.createServer()
+        def on_error(err, req, res):
+            self._on_proxy_error(err, req, res)
+        def on_proxy_response(res):
+            self._on_proxy_response(res)
+        proxy.on("error", on_error)
+        proxy.on("proxyRes", on_proxy_response)
+        return proxy
+
+    def setup_server(self, options):
+        """create the standard node http server to accept request"""
+        def on_request(req, res):
+            self.do_proxy(req, res)
+
+        def _on_connection(sock):
+            self._on_server_connection(sock)
+
+        def _on_client_error(err, sock):
+            r_ip = sock.remoteAddress
+            # hack to find missing remoteAddress
+            if not r_ip:
+                try:
+                    r_ip = sock._peername["address"]
+                except:
+                    pass
+            log.error("HTTP Server clientError:", err, r_ip)
+        def _on_error(err):
+            log.error("HTTP Server Error:", err)
+            process.exit(code=2)
+
+        server = http.createServer(on_request)
+        server.on("connection", _on_connection)
+        server.on("clientError", _on_client_error)
+        server.on("error", _on_error)
+
+        return server
+
+    def do_proxy(self, req, res):
+        """The handler of node proxy server"""
+        raw_host = req.headers["host"] or req.headers["Host"]
+
+        if not raw_host: # as a reverse proxy, cannot handle missing host
+            self._handle_unknown_host(req, res)
+            return
+
+        # some host come with port
+        host_parts = raw_host.split(":")
+        host = host_parts[0]
+        port = int(host_parts[1] or 80)
+
+        domain_map = lutils.fetch_user_domain()
+        if not domain_map[host]:
+            self._handle_unknown_host(req, res)
+            return
+
+        proxy = self.proxy
+
+        # We fake hosting http pages. But we are actually a proxy.
+        # A httpd server normally receives path to the GET/POST request, but
+        # being a proxy, the request need to be absolute URI, not just path.
+        if req.url.indexOf("http") is not 0:
+            if port == 80:
+                url = "http://" + host + req.url
+            else:
+                url = "http://" + host + ":" + port + req.url
+            req.url = url
+        else:
+            url = req.url
+        to_use_proxy = lutils.is_valid_url(url)
+
+        #log.debug("sogou:", self.sogou_info)
+        log.debug("do_proxy[%s] req.url:", self.request_id, url, to_use_proxy)
+        req.headers["X-Droxy-SG"] = "" + to_use_proxy
+        req.headers["X-Droxy-RID"] = "" + self.request_id
+        self.request_id += 1
+
+        # cannot forward cookie settings for other domains in redirect mode
+        forward_cookies = False
+        if req.url.indexOf('http') is 0:
+            forward_cookies = True
+
+        if to_use_proxy:
+            si = self.sogou_info
+            sogou_host = si["ip"] or si["address"]
+            lutils.add_sogou_headers(req.headers, req.headers["host"])
+            proxy_options = {
+                    "target": {
+                        "host": sogou_host, "port": self.sogou_port,
+                        #host: "localhost", port: 9010,
+                    },
+                    "toProxy": True,
+            }
+        else:
+            proxy_options = {
+                    "target": req.url,
+            }
+
+        # log.debug("do_proxy headers before:", req.headers)
+        headers = lutils.filtered_request_headers(
+                req.headers, forward_cookies)
+        req.headers = headers
+        log.debug("do_proxy[%s] headers:", headers["X-Droxy-Rid"], headers,
+                req.socket.remoteAddress)
+
+        proxy.web(req, res, proxy_options)
+
+    def _on_server_connection(self, sock):
+        """Prevent DoS"""
+        raddress = sock.remoteAddress
+        if self.rate_limiter.over_limit(raddress) or self.banned[raddress]:
+            sock.destroy()
+
+    def _on_proxy_error(self, err, req, res):
+        log.error("_on_proxy_error:", err, req.headers["host"],
+                req.url, req.socket.remoteAddress)
+        if 'ECONNRESET' is err.code:
+            self.reset_count += 1
+        elif 'ECONNREFUSED' is err.code:
+            self.refuse_count += 1
+        elif 'ETIMEDOUT' is err.code:
+            self.timeout_count += 1
+        else:
+            self.reset_count += 1 # unknown error
+        self.renew_sogou_server()
+
+    def _on_proxy_response(self, res):
+        #log.debug(res)
+        req = res.req
+        to_use_proxy = int(req._headers["x-droxy-sg"])
+        req_id = int(req._headers["x-droxy-rid"])
+        mitm = False
+        if res.statusCode >= 400:
+            #log.debug("_on_proxy_response:", res)
+            via = res.headers["via"]
+
+            if not via:
+                via = res.headers["Via"]
+            if (to_use_proxy == "true" and
+                    (not via or via.indexOf("sogou-in.domain") < 0)):
+                # someone crapped on our request, mostly chinacache
+                mitm = True
+        if mitm is True:
+            s = res.socket
+            log.warn("We are fucked by man-in-the-middle[%d]:\n",
+                    req_id, res.headers, res.statusCode,
+                    s.remoteAddress + ":" + s.remotePort)
+            # 502: Bad Gateway
+            res.statusCode = 502
+            self.refuse_count += 1
+            self.renew_sogou_server()
+        else:
+            log.debug("_on_proxy_response[%d] headers:", req_id,
+                    res.headers, res.statusCode)
+
+    def _handle_unknown_host(self, req, res):
+        """In case we see an request with unknown/un-routed "host" """
+        # we don't serve pages with proxy and we are not public proxy
+        sock = req.socket
+        raddress = sock.remoteAddress
+        sock.destroy()
+        local_hosts = [self.options["listen_address"],
+                self.options["external_ip"]]
+        if self.public_ip_box is not None:
+            local_hosts.push(self.public_ip_box.ip)
+        if raddress in local_hosts:
+            self.rate_limiter.add_deny(raddress)
+        else:
+            self.banned[raddress] = True
+        log.warn("HTTP Proxy DoS attack:", req.headers, req.url, raddress)
+
+    def _on_listening(self):
+        addr = self.server.address()
+        log.info("Sogou proxy listens on %s:%d",
+                addr.address, addr.port)
+        self.emit("listening")
+
+    def set_public_ip_box(self, public_ip_box):
+        self.public_ip_box = public_ip_box
+
+    def start(self):
+        def _on_listen():
+            self._on_listening()
+
+        self.server.listen(self.proxy_port, self.proxy_host, _on_listen)
+
+        # change sogou server periodically
+        def on_renew_timeout():
+            self.renew_sogou_server(True)
+        sogou_renew_timer = setInterval(on_renew_timeout,
+                self.sogou_renew_timeout)
+        sogou_renew_timer.unref()
+
+def createServer(options):
+    s = ReverseSogouProxy(options)
+    return s
+
+def main():
+    """Run test"""
+    log.set_level(log.DEBUG)
+    def run_local_proxy():
+        proxy = httpProxy.createServer()
+        def on_request(req, res):
+            proxy.web(req, res, {"target": req.url})
+        http.createServer(on_request).listen(9010)
+
+    run_local_proxy()
+    options = {"listen_port":8080, "listen_address":"127.0.0.1",
+            "sogou_dns": "8.8.4.4"}
+    s = ReverseSogouProxy(options)
+    s.start()
+
+    client_options = { "host": "127.0.0.1", "port": 8080,
+        "path": "http://httpbin.org/ip", "headers": { "Host": "httpbin.org" } }
+    # wait a few sec to get a valid sogou proxy ip first
+    log.info("wait for a while...")
+    def on_client_start():
+        log.info("start download...")
+        def on_response(res):
+            res.pipe(process.stdout)
+
+        http.get(client_options, on_response)
+    setTimeout(on_client_start , 12000)
+
+if require.main is JS("module"):
+    main()
+
+exports.ReverseSogouProxy = ReverseSogouProxy
+exports.createServer = createServer

--- a/dns-reverse-proxy/sample-config.json
+++ b/dns-reverse-proxy/sample-config.json
@@ -1,0 +1,8 @@
+{
+    "#comment": "keys start with # are comments",
+    "ip": "192.168.1.5",
+    "#dns-host": "8.8.8.8",
+    "sogou-dns": "8.8.8.8",
+    "#sogou-network": "edu"
+}
+

--- a/shared/urls.js
+++ b/shared/urls.js
@@ -250,6 +250,7 @@ function urls2regexs(url_list) {
 
 // also export as a node.js module
 var exports = exports || {};
+exports.urls2regexs = urls2regexs;
 exports.url_list = unblock_youku.common_urls.concat(unblock_youku.server_extra_urls);
 exports.url_regex_list = urls2regexs(exports.url_list);
 exports.url_whitelist = unblock_youku.server_whitelist_urls;


### PR DESCRIPTION
Add a reverse proxy server with both DNS server and HTTP server combined. The server hijack interested domains and redirect the http request to the domains through the sogou proxy server.

Basically, it is a combination of dnsmasq + privoxy. Just run the server and point your DNS to the server IP and be done with it.

The server do NOT proxy _https_ requests.

All the juicy part are under the `dns-reverse-proxy` directory. Please read the `dns-reverse-proxy/README.md` for more information.
