### PR TITLE
Add option for non sogou proxy servers // FREEBIE

### DIFF
--- a/dns-reverse-proxy/README.md
+++ b/dns-reverse-proxy/README.md
@@ -112,6 +112,9 @@ Options:
   --sogou-dns        DNS used to lookup IP of sogou proxy servers
                                                                [default: null]
   --sogou-network    choose between "edu" and "dxt"            [default: null]
+  --proxy-list       Load user supplied proxy servers either from a comma
+                     seperated list or from a JSON file as a list of strings.
+                                                               [default: null]
   --extra-url-list   load extra url redirect list from a JSON file            
   --ext-ip           for public DNS, the DNS proxy route to the given public
                      IP. If set to "lookup", try to find the public IP


### PR DESCRIPTION
To use non sogou proxy servers, use `--proxy-list` like:
    nodejs droxy.js --proxy-list myproxy.com,you.proxy.net

Also fix a bug where DNS lookup fails if chroot was called.
