### PR TITLE
Amazon.cn kindle ebooks/android appstore purchase // FREEBIE

### DIFF
--- a/shared/urls.js
+++ b/shared/urls.js
@@ -138,6 +138,9 @@ unblock_youku.chrome_extra_urls = [
     'http://aid.video.qq.com/fcgi-bin/userip?*',
     'http://pay.video.qq.com/fcgi-bin/paylimit*',
     'http://chrome.2345.com/dianhua/index.php?m=call&f=check&*',
+    'https://www.amazon.cn/gp/mas/order/ref*',
+    'https://www.amazon.cn/gp/digital/fiona/payment-checkout/ref*',
+    'https://www.amazon.cn/gp/aw/kindle/order.html*',
 
     // 'http://play.baidu.com/*',
     // 'http://zhangmenshiting.baidu.com/*',


### PR DESCRIPTION
#302 #151 #57 // FREEBIE

@zhuzhuor

嘛..amazon.cn kindle和android appstore 網頁版購買的url找到了, 代理流量也不大
不過, 是少有的https加密連接..而且amazon.cn全站都可以手動使用HTTPS
所以mainland io伺服器可以先擋掉它
個人認為可以加到extralist那里, 讓chrome+sogou代理的用戶先用著

但要是android想通過反向代理來使用的話..就得在國內的伺服器另架反向https代理
