### PR TITLE
新英体育新URL

### DIFF
--- a/shared/urls.js
+++ b/shared/urls.js
@@ -122,7 +122,6 @@ unblock_youku.common_urls = [
     'http://vip.sports.cntv.cn/check.do*',
     'http://vip.sports.cntv.cn/play.do*',
     'http://vip.sports.cntv.cn/servlets/encryptvideopath.do*',
-    'http://ssports.com/play/*',
 ];
 
 // only for chrome extension


### PR DESCRIPTION
之前 #353 解决了新英体育播放问题，近日新英加入了新的URL，把集锦类放到上海网络电视台（smg）了，因而复现了 #351 的问题

例子：http://ssports.smgbb.cn/play/1380254.html
SMGBB的其他节目目前不禁海外IP，所以只加入涉及新英的URL
