### PR TITLE
Improve the speed of bilibili

### DIFF
--- a/shared/urls.js
+++ b/shared/urls.js
@@ -221,8 +221,8 @@ unblock_youku.chrome_proxy_urls = unblock_youku.redirect_urls.concat([
     "http://mobile.api.hunantv.com/*",
     'http://www.qie.tv/*',
     'http://www.bilibili.com/video/*',
-    'http://interface.bilibili.com/*',
-    'https://interface.bilibili.com/*',
+    //'http://interface.bilibili.com/*',
+    //'https://interface.bilibili.com/*',
     'https://bangumi.bilibili.com/*',
     // 'http://live-play.acgvideo.com/live/*',
     'http://m10.music.126.net/*', //for the testing of netease music


### PR DESCRIPTION
针对大量用户反馈的B站龟速的问题特地进行的优化。主要是B站的非版权视频所使用的视频分配地址interface.bilibili.com会检测是否有使用代理，如果有使用代理就会加入限速参数使得视频加载龟速（大概只有150k/s），否则上限则大幅提高（约3100k/s）。由于目前这个问题只是在电脑端出现，所以只修改涉及到插件的部分。