### PR TITLE
Add support for Netease Music iOS

### DIFF
--- a/shared/urls.js
+++ b/shared/urls.js
@@ -411,7 +411,7 @@ unblock_youku.pac_proxy_urls = unblock_youku.chrome_proxy_urls.concat(unblock_yo
     'https://app.bilibili.com/*',
     'http://bangumi.bilibili.com/api/*',
     'http://data.bilibili.com/*',
- 
+
 
     // Music apps
     'http://3g.music.qq.com/*',
@@ -478,7 +478,11 @@ unblock_youku.pac_proxy_urls = unblock_youku.chrome_proxy_urls.concat(unblock_yo
     'http://180.153.225.136/*',
     'http://118.244.244.124/*',
     'http://210.129.145.150/*',
-    'http://182.16.230.98/*' // Updated on Jan. 3, for new DNS of apple tv.
+    'http://182.16.230.98/*', // Updated on Jan. 3, for new DNS of apple tv.
+
+    // for NeteaseMusic on iOS
+    'http://103.65.41.126/eapi/*',
+    'http://103.65.41.125/eapi/*'
 ]);
 
 


### PR DESCRIPTION
iOS 网易云音乐访问 API 时直接用的 IP. dig 和手动测试的结果是现在在使用的有两个 IP - `103.65.41.126` 和 `103.65.41.125`.

这个 PR 没有测试过, 并不确定是否能解决问题. 

Issue: https://github.com/uku/Unblock-Youku/issues/807

@zhuzhuor 