### PR TITLE
add another url which youku is requesting to when watching worldcup to urls list

### DIFF
--- a/shared/urls.js
+++ b/shared/urls.js
@@ -64,6 +64,7 @@ unblock_youku.header_urls = [
 
 // These URLs can work with the redirect functionality (mainly used in Flash players).
 unblock_youku.redirect_urls = [
+    'https://dmd-fifajs-h5-ikuweb.youku.com/*',
     'https://dmd-fifa-h5-ikuweb.youku.com/*',
     'http://acs.youku.com/*',
     'https://acs.youku.com/*',


### PR DESCRIPTION
add another url which youku is requesting to when watching worldcup to urls list, right now it returns a 403 and is blocking user from watching the stream
